### PR TITLE
Add Brother Status and Semester endpoints

### DIFF
--- a/api/handlers/semester_handler.go
+++ b/api/handlers/semester_handler.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/pacific-theta-tau/tt-db/api/models"
+)
+
+// /semesters/
+func (h *Handler) GetAllSemesterStatuses(w http.ResponseWriter, r *http.Request) {
+    ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	defer cancel()
+    semester := r.URL.Query().Get("semester")
+
+    // Query for all brother statuses
+    query := `
+    SELECT b.brotherID, b.rollCall, b.firstName, b.lastName, bs.status, s.semesterLabel
+    FROM brotherStatus bs
+    JOIN brothers b ON b.brotherID = bs.brotherID
+    JOIN semester s ON s.semesterID = bs.semesterID
+    `
+    var rows *sql.Rows
+    var err error
+    if semester == "" {
+        // Query without filter
+        rows, err = h.db.QueryContext(ctx, query)
+    } else {
+        // query filtering by semester
+        query += " WHERE semesterLabel = $1"
+        rows, err = h.db.QueryContext(
+            ctx,
+            query,
+            semester,
+        )
+    } 
+
+    // Error handling query
+    fmt.Printf("Querying for all semester statuses:\n%s\n", query)
+    if err != nil {
+        errMsg := fmt.Sprintf("Error while querying for all brother statuses: %s", err.Error())
+        log.Println(errMsg)
+        http.Error(w, errMsg, http.StatusInternalServerError)
+        return
+    }
+
+    log.Println("Parsing brother objects\n")
+    // Parse query rows
+    var brotherStatuses []*models.BrotherStatus
+    for rows.Next(){
+        brotherStatus, err := models.CreateBrotherStatusFromRow(rows)
+		if err != nil {
+            errMsg := fmt.Sprintf("Error while parsing brotherStatus query: '%s'", err.Error())
+            log.Println(errMsg)
+			http.Error(w, errMsg, http.StatusInternalServerError)
+			return
+        }
+        brotherStatuses = append(brotherStatuses, &brotherStatus)
+    }
+
+    log.Println("Building response\n")
+    // Build response
+    if err := json.NewEncoder(w).Encode(brotherStatuses); err != nil {
+        errMsg := fmt.Sprintf("Erro while encoding response: '%s'", err.Error())
+        log.Println(errMsg)
+        http.Error(w, errMsg, http.StatusInternalServerError)
+        return
+    }
+    w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}

--- a/api/handlers/semester_handler.go
+++ b/api/handlers/semester_handler.go
@@ -13,7 +13,7 @@ import (
 
 // Get all semester labels. E.g.: "Spring 2024"
 /* GET /semesters?semester=[optional] */
-func (h *Handler) GetAllSemesterStatuses(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) GetAllSemesterLabels(w http.ResponseWriter, r *http.Request) {
     ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
 	defer cancel()
 

--- a/api/handlers/status_handler.go
+++ b/api/handlers/status_handler.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/pacific-theta-tau/tt-db/api/models"
 )
 
@@ -72,4 +73,59 @@ func (h *Handler) GetAllBrotherStatuses(w http.ResponseWriter, r *http.Request) 
     }
     w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+}
+
+// TODO: this is the same as POST `/api/brothers/{id}/statuses endpoint. Refactor or remove one
+/* POST /statuses */
+func (h *Handler) CreateStatusForBrother(w http.ResponseWriter, r *http.Request) {
+    ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	defer cancel()
+
+    var requestBody struct {
+        BrotherID   int `json:"brotherID"`
+        SemesterID  int `json:"semesterID"`
+        Status      string `json:"status"`
+    }
+    // Parse body
+    err := json.NewDecoder(r.Body).Decode(&requestBody)
+    if err != nil {
+        errMsg := fmt.Sprintf("Error while parsing request body data: %s", err.Error())
+        log.Println(errMsg)
+        http.Error(w, errMsg, http.StatusInternalServerError)
+        return
+    }
+    // Validate received data
+    validate := validator.New()
+    if err := validate.Struct(requestBody); err != nil {
+        errMsg := fmt.Sprintf("Invalid Input: %s", err.Error())
+        log.Println(errMsg)
+        http.Error(w, errMsg, http.StatusBadRequest)
+        return
+    }
+
+    // Validate received data
+    query := `
+    INSERT INTO brotherStatus (brotherID, semesterID, status)
+    VALUES ($1, $2, $3)
+    `
+    _, err = h.db.QueryContext(
+        ctx,
+        query,
+        requestBody.BrotherID,
+        requestBody.SemesterID,
+        requestBody.Status,
+    )
+    if err != nil {
+        errMsg := fmt.Sprintf("Query error:\n\t'%s'\n", err.Error())
+        log.Println(errMsg)
+        log.Println("Sending HTTP error response\n")
+		http.Error(w, errMsg, http.StatusInternalServerError)
+        log.Println("After sending error response\n")
+		return
+	}
+
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Created Brother Status successfully"))
+
 }

--- a/api/handlers/status_handler.go
+++ b/api/handlers/status_handler.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/pacific-theta-tau/tt-db/api/models"
+)
+
+// GET /semesters?semester=[optional]
+func (h *Handler) GetAllBrotherStatuses(w http.ResponseWriter, r *http.Request) {
+    ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	defer cancel()
+    semester := r.URL.Query().Get("semester")
+
+    // Query for all brother statuses
+    query := `
+    SELECT b.brotherID, b.rollCall, b.firstName, b.lastName, bs.status, s.semesterLabel
+    FROM brotherStatus bs
+    JOIN brothers b ON b.brotherID = bs.brotherID
+    JOIN semester s ON s.semesterID = bs.semesterID
+    `
+    var rows *sql.Rows
+    var err error
+    if semester == "" {
+        // Query without filter
+        rows, err = h.db.QueryContext(ctx, query)
+    } else {
+        // query filtering by semester
+        query += " WHERE semesterLabel = $1"
+        rows, err = h.db.QueryContext(
+            ctx,
+            query,
+            semester,
+        )
+    } 
+
+    // Error handling query
+    fmt.Printf("Querying for all semester statuses:\n%s\n", query)
+    if err != nil {
+        errMsg := fmt.Sprintf("Error while querying for all brother statuses: %s", err.Error())
+        log.Println(errMsg)
+        http.Error(w, errMsg, http.StatusInternalServerError)
+        return
+    }
+
+    log.Println("Parsing brother objects\n")
+    // Parse query rows
+    var brotherStatuses []*models.BrotherStatus
+    for rows.Next(){
+        brotherStatus, err := models.CreateBrotherStatusFromRow(rows)
+		if err != nil {
+            errMsg := fmt.Sprintf("Error while parsing brotherStatus query: '%s'", err.Error())
+            log.Println(errMsg)
+			http.Error(w, errMsg, http.StatusInternalServerError)
+			return
+        }
+        brotherStatuses = append(brotherStatuses, &brotherStatus)
+    }
+
+    log.Println("Building response\n")
+    // Build response
+    if err := json.NewEncoder(w).Encode(brotherStatuses); err != nil {
+        errMsg := fmt.Sprintf("Erro while encoding response: '%s'", err.Error())
+        log.Println(errMsg)
+        http.Error(w, errMsg, http.StatusInternalServerError)
+        return
+    }
+    w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}

--- a/api/models/semester.go
+++ b/api/models/semester.go
@@ -1,6 +1,22 @@
 package models
 
+import "database/sql"
+
 type Semester struct {
     SemesterID      string `json:"semesterID"`
     SemesterLabel   string `json:"semesterLabel"`
+}
+
+// Helper function to scan SQL row and create new Brother instance
+func CreateSemesterFromRow(row *sql.Rows) (Semester, error) {
+    var semester Semester
+	err := row.Scan(
+        &semester.SemesterID,
+		&semester.SemesterLabel,
+	)
+	if err != nil {
+		return Semester{}, err
+	}
+
+	return semester, err
 }

--- a/api/models/semester.go
+++ b/api/models/semester.go
@@ -1,0 +1,6 @@
+package models
+
+type Semester struct {
+    SemesterID      string `json:"semesterID"`
+    SemesterLabel   string `json:"semesterLabel"`
+}

--- a/api/models/status.go
+++ b/api/models/status.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Status struct {
-    Semester string `json:"semesterStatus"`
+    Semester string `json:"semesterLabel"`
     Status string `json:"status"`
 }
 
@@ -21,4 +21,30 @@ func CreateStatusFromRow(row *sql.Rows) (Status, error) {
 	}
 
 	return status, err
+}
+
+type BrotherStatus struct {
+    BrotherID   int `json:"brotherID"`
+    RollCall    string `json:"rollCall"`
+    FirstName   string `json:"firstName"`
+    LastName    string `jsong:"lastName"`
+    Status      string `json:"status"`
+    Semester    string `json:"semesterLabel"`
+}
+
+func CreateBrotherStatusFromRow(row *sql.Rows) (BrotherStatus, error) {
+    var brotherStatus BrotherStatus
+    err := row.Scan(
+        &brotherStatus.BrotherID,
+        &brotherStatus.RollCall,
+        &brotherStatus.FirstName,
+        &brotherStatus.LastName,
+        &brotherStatus.Status,
+        &brotherStatus.Semester,
+    )
+    if err != nil {
+        return BrotherStatus{}, err
+    }
+
+    return brotherStatus, err
 }

--- a/api/models/status.go
+++ b/api/models/status.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"database/sql"
+)
+
+type Status struct {
+    Semester string `json:"semesterStatus"`
+    Status string `json:"status"`
+}
+
+// Helper function to scan SQL row and create new Brother instance
+func CreateStatusFromRow(row *sql.Rows) (Status, error) {
+    var status Status
+	err := row.Scan(
+        &status.Semester,
+		&status.Status,
+	)
+	if err != nil {
+		return Status{}, err
+	}
+
+	return status, err
+}

--- a/api/server.go
+++ b/api/server.go
@@ -98,6 +98,7 @@ func setupRoutes(handler *handlers.Handler) *chi.Mux {
 
     // semester endpoints
     r.Get("/api/semesters", handler.GetAllSemesterStatuses)
+    r.Post("/api/semesters", handler.CreateSemesterLabel)
 
 	return r
 }

--- a/api/server.go
+++ b/api/server.go
@@ -65,9 +65,11 @@ func setupRoutes(handler *handlers.Handler) *chi.Mux {
     })
     r.Use(corsHandler.Handler)
 
+    // Endpoints
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Hello World!"))
 	})
+
 	// brothers endpoint
 	r.Get("/api/brothers", handler.GetAllBrothers)
 	//r.Get("/api/brothers/{rollCall}", handler.GetBrotherByRollCall)
@@ -76,14 +78,17 @@ func setupRoutes(handler *handlers.Handler) *chi.Mux {
 	r.Put("/api/brothers", handler.UpdateBrother)
 	r.Delete("/api/brothers", handler.RemoveBrother)
 
-    // TODO: events endpoint
+    // brotherStatus endpoints
+    r.Get("/api/brothers/{id}/statuses", handler.GetBrotherStatusHistory)
+
+    // events endpoint
 	r.Get("/api/events", handler.GetAllEvents)
 	r.Get("/api/events/{eventID}", handler.GetEventByEventID)
 	r.Get("/api/events/{eventID}/attendance", handler.GetEventAttendance)
     r.Post("/api/events", handler.InsertEvent)
     r.Put("/api/events", handler.UpdateEventByID)
 
-    // TODO: attendance endpoints
+    // attendance endpoints
     r.Get("/api/attendance", handler.GetAllAttendanceRecords)
     r.Get("/api/attendance/{eventID}", handler.GetAttendanceFromEventID)
     r.Post("/api/attendance", handler.CreateAttendance)

--- a/api/server.go
+++ b/api/server.go
@@ -80,6 +80,7 @@ func setupRoutes(handler *handlers.Handler) *chi.Mux {
 
     // brotherStatus endpoints
     r.Get("/api/brothers/{id}/statuses", handler.GetBrotherStatusHistory)
+    r.Post("/api/brothers/{id}/statuses", handler.CreateBrotherStatus)
 
     // events endpoint
 	r.Get("/api/events", handler.GetAllEvents)

--- a/api/server.go
+++ b/api/server.go
@@ -96,5 +96,8 @@ func setupRoutes(handler *handlers.Handler) *chi.Mux {
     r.Put("/api/attendance", handler.UpdateAttendanceRecord)
     r.Delete("/api/attendance", handler.DeleteAttendanceRecord)
 
+    // semester endpoints
+    r.Get("/api/semesters", handler.GetAllSemesterStatuses)
+
 	return r
 }

--- a/api/server.go
+++ b/api/server.go
@@ -79,6 +79,7 @@ func setupRoutes(handler *handlers.Handler) *chi.Mux {
 	r.Delete("/api/brothers", handler.RemoveBrother)
 
     // brotherStatus endpoints
+    r.Get("/api/statuses", handler.GetAllBrotherStatuses)
     r.Get("/api/brothers/{id}/statuses", handler.GetBrotherStatusHistory)
     r.Post("/api/brothers/{id}/statuses", handler.CreateBrotherStatus)
 
@@ -97,7 +98,7 @@ func setupRoutes(handler *handlers.Handler) *chi.Mux {
     r.Delete("/api/attendance", handler.DeleteAttendanceRecord)
 
     // semester endpoints
-    r.Get("/api/semesters", handler.GetAllSemesterStatuses)
+    r.Get("/api/semesters", handler.GetAllSemesterLabels)
     r.Post("/api/semesters", handler.CreateSemesterLabel)
 
 	return r

--- a/db/scripts/init.sql
+++ b/db/scripts/init.sql
@@ -33,20 +33,44 @@ CREATE TABLE IF NOT EXISTS attendance(
 	PRIMARY KEY (brotherID, eventID)  -- compound PK
 );
 
+CREATE TABLE IF NOT EXISTS semester(
+    semesterID SERIAL PRIMARY KEY,
+    semesterLabel VARCHAR(20)
+);
+
+CREATE TABLE IF NOT EXISTS brotherStatus(
+    brotherID INT REFERENCES brothers(brotherID),
+    semesterID INT REFERENCES semester(semesterID),
+    status status,
+    PRIMARY KEY (brotherID, semesterID)
+);
+
 
 -- mock entries for testing
 INSERT INTO brothers (rollCall, firstName, lastName, status, className, email, phoneNumber, badStanding)
-VALUES (239, 'Nicolas', 'Ahn', 'Active', 'Chi', 'na@gmail.com', '(123) 456-7890', 0);
+VALUES
+    (1, 'John', 'Doe', 'Active', 'Chi', 'na@gmail.com', '(123) 456-7890', 0)
+;
 
 INSERT INTO eventsCategory (categoryID, categoryName)
 VALUES
-(1, 'Professional Development'),
-(2, 'Brotherhood'),
-(3, 'Community Service'); 
+    (1, 'Professional Development'),
+    (2, 'Brotherhood'),
+    (3, 'Community Service')
+;
 
 INSERT INTO events (eventName, categoryID, eventLocation, eventDate)
 VALUES 
     ('CO-OP Panel', 1, 'Regent Room', '1/28/24'),
-    ('Movies', 2, 'CTC', '3/14/24');
+    ('Movies', 2, 'CTC', '3/14/24')
+;
 
+INSERT INTO semester (semesterLabel) VALUES ('Spring 2023', 'Fall 2023', 'Spring 2024', 'Fall 2024');
 
+INSERT INTO brotherStatus (brotherID, semesterID, status)
+VALUES
+    (1, 1, 'Active'),
+    (1, 2, 'Co-op'),
+    (1, 3,' Active'),
+    (1, 4, 'Alumni')
+;

--- a/db/scripts/init.sql
+++ b/db/scripts/init.sql
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS attendance(
 
 CREATE TABLE IF NOT EXISTS semester(
     semesterID SERIAL PRIMARY KEY,
-    semesterLabel VARCHAR(20)
+    semesterLabel VARCHAR(20) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS brotherStatus(

--- a/db/scripts/init.sql
+++ b/db/scripts/init.sql
@@ -65,7 +65,7 @@ VALUES
     ('Movies', 2, 'CTC', '3/14/24')
 ;
 
-INSERT INTO semester (semesterLabel) VALUES ('Spring 2023', 'Fall 2023', 'Spring 2024', 'Fall 2024');
+INSERT INTO semester (semesterLabel) VALUES ('Spring 2023'), ('Fall 2023'), ('Spring 2024'), ('Fall 2024');
 
 INSERT INTO brotherStatus (brotherID, semesterID, status)
 VALUES


### PR DESCRIPTION
# Changes
* New tables to keep track of status of a Brother in different semesters
![image](https://github.com/user-attachments/assets/05602503-5aff-47bd-9f0b-b399b18170b4)

* New endpoints reflecting schema update:
  * status of a brother (`Active`, `Alumnus`, 'Co-op`, etc..) for a specific `semester`
  * `semester` (e.g. `Spring 2024`, `Fall 2024`)